### PR TITLE
Updating the schema to include our db name

### DIFF
--- a/examready-backend/db/schema.sql
+++ b/examready-backend/db/schema.sql
@@ -1,5 +1,10 @@
 -- ExamReady Africa Database Schema
 
+-- Database name: examready_db
+DROP DATABASE IF EXISTS examready_db;
+CREATE DATABASE examready_db;
+USE examready_db;
+
 -- Questions Table
 CREATE TABLE questions (
     id INT AUTO_INCREMENT PRIMARY KEY,


### PR DESCRIPTION
Add database name to schema

- Now creates 'examready_db' automatically
- No need to manually create database first